### PR TITLE
chore: rename Codex to Logos Storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
-          - stable
-          - beta
-          - nightly
+          - 1.85.0
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 name = "ark-circom"
 version = "0.1.0"
-source = "git+https://github.com/codex-storage/circom-compat.git?rev=71f1ceb11aef27256#71f1ceb11aef27256555d12380a592675db8b477"
+source = "git+https://github.com/logos-storage/circom-compat.git?rev=71f1ceb11aef27256#71f1ceb11aef27256555d12380a592675db8b477"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = [
 
 [dependencies]
 
-ark-circom = { git = "https://github.com/codex-storage/circom-compat.git", rev = "71f1ceb11aef27256", features = ["circom-2", "ethereum"]}
+ark-circom = { git = "https://github.com/logos-storage/circom-compat.git", rev = "71f1ceb11aef27256", features = ["circom-2", "ethereum"]}
 
 ark-crypto-primitives = { version = "=0.4.0" }
 ark-ec = { version = "=0.4.1", default-features = false, features = ["parallel"] }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Codex Storage
+Copyright (c) 2025 Logos Storage
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I updated the version to 1.85.0 because the code doesn't compile with last versions of Rust.