### PR TITLE
nix: fix fetching of crates which now require agent overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,16 @@
         "x86_64-darwin" "aarch64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs stableSystems;
-      pkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+      # crates.io's WAF returns 403 for the default `curl/X.Y.Z` User-Agent.
+      fetchurlUserAgentOverlay = final: prev: {
+        fetchurl = args: prev.fetchurl (args // {
+          curlOptsList = (args.curlOptsList or []) ++ [ "-A" "logos-storage-nix" ];
+        });
+      };
+      pkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+        overlays = [ fetchurlUserAgentOverlay ];
+      });
     in
     {
       packages = forAllSystems (system: let


### PR DESCRIPTION
Else in status-go CI we get this failure : 
```
crate-alloy-rlp>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-crypto-primitives>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-alloy-rlp> curl: (22) The requested URL returned error: 403
crate-ark-crypto-primitives> curl: (22) The requested URL returned error: 403
crate-ark-ec>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-ec> curl: (22) The requested URL returned error: 403
crate-ark-ff>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-ff> curl: (22) The requested URL returned error: 403
crate-ark-groth16>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-groth16> curl: (22) The requested URL returned error: 403
crate-ark-poly>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-poly> curl: (22) The requested URL returned error: 403
crate-ark-snark>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-snark> curl: (22) The requested URL returned error: 403
crate-ethers-core>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ark-serialize>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-ethers-core> curl: (22) The requested URL returned error: 403
crate-ark-serialize> curl: (22) The requested URL returned error: 403
crate-scale-info>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
crate-scale-info> curl: (22) The requested URL returned error: 403
crate-ark-crypto-primitives> error: cannot download crate-ark-crypto-primitives-0.4.0.tar.gz from any mirror
error: Cannot build '/nix/store/lm210ryfadn6vvs361w5p95bnnnhdf1g-crate-ark-crypto-primitives-0.4.0.tar.gz.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/d4rxr5imz7q8gnpz33abpny8rv7qbryd-crate-ark-crypto-primitives-0.4.0.tar.gz
       Last 17 log lines:
       >
       > trying https://crates.io/api/v1/crates/ark-crypto-primitives/0.4.0/download
       >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
       >                                  Dload  Upload   Total   Spent    Left  Speed
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 1 second. 3 retries left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 2 seconds. 2 retries
       > Warning: left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > Warning: Problem (retrying all errors). Will retry in 4 seconds. 1 retry left.
       >   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
       > curl: (22) The requested URL returned error: 403
       > error: cannot download crate-ark-crypto-primitives-0.4.0.tar.gz from any mirror
       For full logs, run:
         nix log /nix/store/lm210ryfadn6vvs361w5p95bnnnhdf1g-crate-ark-crypto-primitives-0.4.0.tar.gz.drv
error: Cannot build '/nix/store/lqamh3mbnq2w5klyndgdkx7rlyxsrkpk-ark-crypto-primitives-0.4.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/vlgn4msdjb31i499grnmj3vz6c3f9jh8-ark-crypto-primitives-0.4.0
error: Build failed due to failed dependency
error: Cannot build '/nix/store/c27fnbqrqaagcxn81y04izj1yfg82c25-cargo-vendor-dir.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/jfd5p6gl3a1sdc6aqxn720n0qcf91ayh-cargo-vendor-dir
error: Build failed due to failed dependency
error: Cannot build '/nix/store/bn8s4c113hhsvhg46lmazj0p04z45fba-circom-compat-ffi-0.1.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/7myhxaq2yyqdw74pspmpnsd6ywwiqypg-circom-compat-ffi-0.1.0
error: Build failed due to failed dependency
error: Cannot build '/nix/store/7s1kqgpvb03a4wn970kkkil1kk33wv52-storage-0.1.0-3c09f008.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/z1ia4xdcl9dlib0164zm6iia1s80nmah-storage-0.1.0-3c09f008
error: Build failed due to failed dependency
error: Cannot build '/nix/store/5pah3l0yx5hl0wxyvp40xh3x5a7zd2xy-status-go-61245b6e12d3fe29d432e466a12b8feaec391b36.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/ackv4j3m28w9rivslvc7nhi8vll28wx9-status-go-61245b6e12d3fe29d432e466a12b8feaec391b36
error: Build failed due to failed dependency
script returned exit code 1
```